### PR TITLE
[FIX] snippets: Warning in snipMate.vim Snippet is already defined

### DIFF
--- a/vim/snippets/_.snippets
+++ b/vim/snippets/_.snippets
@@ -1,7 +1,0 @@
-# Global snippets
-
-# (c) holds no legal value ;)
-snippet c)
-	`&enc[:2] == "utf" ? "©" : "(c)"` Copyright `strftime("%Y")` ${1:`g:snips_author`}. All Rights Reserved.${2}
-snippet date
-	`strftime("%Y-%m-%d")`

--- a/vim/snippets/python.snippets
+++ b/vim/snippets/python.snippets
@@ -1,11 +1,5 @@
-snippet #!
-	#!/usr/bin/env python
 snippet coding
 	# -*- coding: ${1:utf-8} -*-
-snippet imp
-	import ${1:module}
-snippet from
-	from ${1:module} import ${2:class}
 snippet osv <= 6.0
 	from osv import osv
 	from osv import fields
@@ -18,27 +12,6 @@ snippet osv >= 6.1
 snippet osv >= 8.0
 	from openerp import models, api, fields, exceptions
 	${1}
-# Module Docstring
-snippet docs
-	'''
-	File: ${1:`Filename('$1.py', 'foo.py')`}
-	Author: ${2:`g:snips_author`}
-	Description: ${3}
-	'''
-snippet wh
-	while ${1:condition}:
-		${2:# code...}
-snippet for
-	for ${1:needle} in ${2:haystack}:
-		${3:# code...}
-# New Class
-snippet cl
-	class ${1:ClassName}(${2:object}):
-		"""${3:docstring for $1}"""
-		def __init__(self, ${4:arg}):
-			${5:super($1, self).__init__()}
-			self.$4 = $4
-			${6}
 snippet copyright
 	##############################################################################
 	#
@@ -690,62 +663,11 @@ snippet fm
 # New Function
 snippet super
 	super(${1:ClassName}, self).${2:methodName}(cr, uid, ${3:ids}, ${4}context=context)${5}
-snippet def
-	def ${1:fname}(${2:`indent('.') ? 'self' : ''`}):
-	    """${3:docstring for $1}"""
-	    ${4:pass}
-snippet deff
-	def ${1:fname}(${2:`indent('.') ? 'self' : ''`}):
-	    ${3}
-# New Method
 snippet defs
 	def ${1:mname}(self, ${2:arg}):
 	    ${3:pass}
-# New Property
-snippet property
-	def ${1:foo}():
-	    doc = "${2:The $1 property.}"
-	    def fget(self):
-	        ${3:return self._$1}
-	    def fset(self, value):
-	        ${4:self._$1 = value}
-# Lambda
-snippet ld
-	${1:var} = lambda ${2:vars} : ${3:action}
 snippet self.
 	self.${1:method}(${2})
-snippet try Try/Except
-	try:
-	    ${1:pass}
-	except ${2:Exception}, ${3:e}:
-	    ${4:raise $3}
-snippet try Try/Except/Else
-	try:
-	    ${1:pass}
-	except ${2:Exception}, ${3:e}:
-	    ${4:raise $3}
-	else:
-	    ${5:pass}
-snippet try Try/Except/Finally
-	try:
-	    ${1:pass}
-	except ${2:Exception}, ${3:e}:
-	    ${4:raise $3}
-	finally:
-	    ${5:pass}
-snippet try Try/Except/Else/Finally
-	try:
-	    ${1:pass}
-	except ${2:Exception}, ${3:e}:
-	    ${4:raise $3}
-	else:
-	    ${5:pass}
-	finally:
-		${6:pass}
-# if __name__ == '__main__':
-snippet ifmain
-	if __name__ == '__main__':
-	    ${1:main()}
 # __magic__
 snippet _ __init__
 	__${1:init}__${2}
@@ -753,9 +675,6 @@ snippet ifcontext
 	if context is None:
 	    context = {}
 	${1}
-snippet pdb
-	import pdb
-	pdb.set_trace()
 snippet date to_string
 	fields.Datetime.to_string(${1:datetime instance})${2}
 snippet date from_string


### PR DESCRIPTION
Using spf13 the plugin https://github.com/honza/vim-snippets is installed where there are standard snippets and duplicated.

- Warning in snipMate.vim Snippet is already defined
  - Duplicated from https://github.com/honza/vim-snippets/blob/master/snippets/python.snippets
- Warning 'c)' and 'date' snippet are already defined
  - Duplicated from https://github.com/honza/vim-snippets/blob/master/snippets/_.snippets